### PR TITLE
本文データの保存と音声ファイル生成の問題を修正

### DIFF
--- a/src/news_assistant/articles/router.py
+++ b/src/news_assistant/articles/router.py
@@ -13,9 +13,9 @@ router = APIRouter()
 async def create_article(article: ArticleCreate, db: Session = Depends(get_db)) -> ArticleResponse:
     """記事を新規作成"""
     try:
-        # コンテンツ処理（要約生成含む）を実行
+        # コンテンツ処理（要約生成含む）と音声生成を実行
         service = ArticleService()
-        db_article = service.create_article(db, article)
+        db_article = await service.create_article_with_audio(db, article)
         return ArticleResponse.model_validate(db_article)
     except DatabaseError as e:
         if e.error_code == "DUPLICATE_URL":

--- a/tests/test_articles.py
+++ b/tests/test_articles.py
@@ -189,7 +189,7 @@ def test_article_audio_generation(client: TestClient) -> None:
     article_data = {"url": "https://example.com/audio-test", "title": "Audio Test Article"}
 
     with patch("news_assistant.content.processor.ContentProcessor.process_url") as mock_process, \
-         patch("news_assistant.articles.service.asyncio.create_task") as mock_task:
+         patch("news_assistant.articles.service.ArticleService._generate_article_audio") as mock_audio:
             from pydantic import HttpUrl
 
             from news_assistant.content.schemas import ProcessedContent
@@ -206,8 +206,8 @@ def test_article_audio_generation(client: TestClient) -> None:
             response = client.post("/api/articles/", json=article_data)
 
     assert response.status_code == 201
-    # 音声生成タスクが作成されたことを確認
-    mock_task.assert_called_once()
+    # 音声生成メソッドが呼ばれたことを確認
+    mock_audio.assert_called_once()
 
 
 def test_speech_service_audio_path_generation() -> None:


### PR DESCRIPTION
## 概要
Issue #7 で報告された、記事作成時に本文データが保存されず、本文の音声ファイルが生成されない問題を修正しました。

## 変更内容

### 1. ContentProcessorの改善
- 抽出したテキストを `data/raw/article_{id}.txt` として保存する機能を追加
- `data/raw` ディレクトリの自動作成処理を追加

### 2. 音声生成の非同期処理を修正
- `asyncio.create_task()` の問題を解決するため、`create_article_with_audio()` メソッドを追加
- 記事作成と音声生成を適切に非同期処理で実行

### 3. 長文テキストの音声生成対応
- Azure Speech APIの10,000文字制限を超える場合は9,000文字に切り詰めて処理
- 切り詰めた場合はログに警告を出力

### 4. テストの修正
- 新しい実装に合わせてモックの対象を更新

## 動作確認
- [x] 記事作成時に `data/raw/article_{id}.txt` が作成される
- [x] 要約音声ファイル `data/speech/{id}-summary.wav` が生成される
- [x] 本文音声ファイル `data/speech/{id}-full.wav` が生成される
- [x] 長文（9,000文字以上）の記事でも正常に処理される
- [x] すべてのテストが成功（64 passed）
- [x] Linting、Type checkingが成功

## テスト結果
```
make all
✅ Linting (ruff) - Success
✅ Type checking (mypy) - Success
✅ Tests - 64 passed, 3 warnings
```

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)