### PR TITLE
feat: OpenAI TTS APIを統合して音声プロバイダーを選択可能に (issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - **記事の自動処理**: URLから記事のタイトル・内容を自動抽出
 - **AI要約自動生成**: OpenAI APIを使用した高品質な要約生成
-- **音声変換機能**: Azure Text-to-Speech APIによるテキスト音声変換
+- **音声変換機能**: Azure/OpenAI Text-to-Speech APIによるテキスト音声変換
 - **多様なコンテンツ対応**: HTML、PDF、テキストファイルの処理
 - **RESTful API**: 記事の登録・取得・更新・削除
 - **ヘルスチェック機能**: システム状態の監視
@@ -46,12 +46,20 @@
 `.env`ファイルを作成して以下を設定：
 
 ```bash
-# OpenAI API設定（要約機能用）
+# OpenAI API設定（要約・音声機能用）
 OPENAI_API_KEY=your_openai_api_key_here
 
-# Azure Speech Service設定（音声変換機能用）
+# 音声プロバイダー設定
+SPEECH_PROVIDER=azure  # "azure" または "openai"
+
+# Azure Speech Service設定（SPEECH_PROVIDER=azureの場合）
 AZURE_SPEECH_KEY=your_azure_speech_key_here
 AZURE_SPEECH_REGION=your_azure_region_here
+
+# OpenAI TTS設定（SPEECH_PROVIDER=openaiの場合）
+OPENAI_TTS_MODEL=tts-1  # "tts-1" または "tts-1-hd"
+OPENAI_TTS_VOICE=alloy  # alloy, echo, fable, onyx, nova, shimmer
+OPENAI_TTS_SPEED=1.0    # 0.25-4.0
 
 # データベース設定
 NEWS_ASSISTANT_DB_URL=sqlite:///./data/news.db
@@ -211,10 +219,13 @@ news-assistant/
 - **schemas.py**: コンテンツデータスキーマ
 
 #### 4. **speech/** - 音声変換機能
-- **service.py**: Azure Text-to-Speech API統合・音声合成サービス
+- **service.py**: Text-to-Speech API統合・音声合成サービス
 - **schemas.py**: 音声設定・リクエスト・レスポンススキーマ
 - **exceptions.py**: 音声変換専用例外クラス
-- **プロバイダー**: Azure Speech Service、Mock（テスト用）
+- **プロバイダー**: 
+  - Azure Speech Service（日本語最適化、SSML対応）
+  - OpenAI TTS（6種類の音声、高品質モデル）
+  - Mock（テスト用）
 
 #### 5. **core/** - 共通基盤
 - **config.py**: 環境変数・アプリケーション設定
@@ -239,6 +250,36 @@ curl -X POST "http://localhost:8000/api/articles/" \
     "title": "記事タイトル"
   }'
 ```
+
+### 音声プロバイダーの選択
+
+本システムは2つの音声プロバイダーをサポートしています：
+
+#### Azure Speech Service
+- **特徴**: 日本語に最適化、SSML対応、詳細な音声調整可能
+- **設定方法**:
+  ```bash
+  SPEECH_PROVIDER=azure
+  AZURE_SPEECH_KEY=your_key
+  AZURE_SPEECH_REGION=japaneast
+  ```
+
+#### OpenAI TTS
+- **特徴**: シンプルなAPI、6種類の音声、高品質モデル（tts-1-hd）
+- **音声オプション**:
+  - `alloy`: 自然でスムーズ
+  - `echo`: 明瞭で正確
+  - `fable`: 温かみのある声
+  - `onyx`: 深く権威的
+  - `nova`: 明るくエネルギッシュ
+  - `shimmer`: 柔らかく優しい
+- **設定方法**:
+  ```bash
+  SPEECH_PROVIDER=openai
+  OPENAI_TTS_MODEL=tts-1-hd  # または tts-1
+  OPENAI_TTS_VOICE=nova
+  OPENAI_TTS_SPEED=1.2       # 0.25-4.0
+  ```
 
 ## 設計ドキュメント
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - AZURE_SPEECH_KEY=${AZURE_SPEECH_KEY}
       - AZURE_SPEECH_REGION=${AZURE_SPEECH_REGION:-japaneast}
+      - SPEECH_PROVIDER=${SPEECH_PROVIDER:-azure}
+      - OPENAI_TTS_MODEL=${OPENAI_TTS_MODEL:-tts-1}
+      - OPENAI_TTS_VOICE=${OPENAI_TTS_VOICE:-alloy}
+      - OPENAI_TTS_SPEED=${OPENAI_TTS_SPEED:-1.0}
       - ENVIRONMENT=development
     restart: unless-stopped
 
@@ -39,6 +43,10 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - AZURE_SPEECH_KEY=${AZURE_SPEECH_KEY}
       - AZURE_SPEECH_REGION=${AZURE_SPEECH_REGION:-japaneast}
+      - SPEECH_PROVIDER=${SPEECH_PROVIDER:-azure}
+      - OPENAI_TTS_MODEL=${OPENAI_TTS_MODEL:-tts-1}
+      - OPENAI_TTS_VOICE=${OPENAI_TTS_VOICE:-alloy}
+      - OPENAI_TTS_SPEED=${OPENAI_TTS_SPEED:-1.0}
       - ENVIRONMENT=testing
 
   # Poetry管理用
@@ -61,6 +69,10 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - AZURE_SPEECH_KEY=${AZURE_SPEECH_KEY}
       - AZURE_SPEECH_REGION=${AZURE_SPEECH_REGION:-japaneast}
+      - SPEECH_PROVIDER=${SPEECH_PROVIDER:-azure}
+      - OPENAI_TTS_MODEL=${OPENAI_TTS_MODEL:-tts-1}
+      - OPENAI_TTS_VOICE=${OPENAI_TTS_VOICE:-alloy}
+      - OPENAI_TTS_SPEED=${OPENAI_TTS_SPEED:-1.0}
       - ENVIRONMENT=development
 
 volumes:

--- a/src/news_assistant/core/config.py
+++ b/src/news_assistant/core/config.py
@@ -37,6 +37,30 @@ class Settings(BaseSettings):
         default="japaneast", alias="AZURE_SPEECH_REGION", description="Azure Speech Serviceリージョン"
     )
 
+    # Speech Provider設定
+    speech_provider: str = Field(
+        default="azure",
+        alias="SPEECH_PROVIDER",
+        description="使用する音声プロバイダー (azure, openai)"
+    )
+
+    # OpenAI TTS設定
+    openai_tts_model: str = Field(
+        default="tts-1",
+        alias="OPENAI_TTS_MODEL",
+        description="OpenAI TTSモデル (tts-1, tts-1-hd)"
+    )
+    openai_tts_voice: str = Field(
+        default="alloy",
+        alias="OPENAI_TTS_VOICE",
+        description="OpenAI TTS音声 (alloy, echo, fable, onyx, nova, shimmer)"
+    )
+    openai_tts_speed: float = Field(
+        default=1.0,
+        alias="OPENAI_TTS_SPEED",
+        description="OpenAI TTS速度 (0.25-4.0)"
+    )
+
     # ファイル保存設定
     data_dir: str = Field(default="data", description="データファイル保存ディレクトリ")
 

--- a/src/news_assistant/speech/service.py
+++ b/src/news_assistant/speech/service.py
@@ -424,10 +424,12 @@ class SpeechService:
     def __init__(self, provider: SpeechProvider | None = None) -> None:
         if provider is None:
             # 設定に基づいてプロバイダーを選択
+            logger.info(f"音声プロバイダー設定: SPEECH_PROVIDER={settings.speech_provider}")
             if settings.speech_provider == "openai":
                 if settings.openai_api_key:
                     provider = OpenAISpeechProvider()
                     logger.info("OpenAI TTS プロバイダーを使用します。")
+                    logger.info(f"OpenAI TTS設定: model={settings.openai_tts_model}, voice={settings.openai_tts_voice}, speed={settings.openai_tts_speed}")
                 else:
                     logger.warning("OpenAI APIキーが設定されていません。モックプロバイダーを使用します。")
                     provider = MockSpeechProvider()

--- a/src/news_assistant/speech/service.py
+++ b/src/news_assistant/speech/service.py
@@ -1,14 +1,19 @@
-"""Azure Text-to-Speech サービス実装"""
+"""Text-to-Speech サービス実装"""
 
 import logging
 import uuid
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 try:
     import azure.cognitiveservices.speech as speechsdk
 except ImportError:
     speechsdk = None
+
+try:
+    import openai
+except ImportError:
+    openai = None  # type: ignore[assignment]
 
 from news_assistant.core.config import settings
 
@@ -265,17 +270,176 @@ class MockSpeechProvider:
         return VoiceListResponse(voices=mock_voices, total_count=len(mock_voices))
 
 
+class OpenAISpeechProvider:
+    """OpenAI TTS プロバイダー"""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        if openai is None:
+            raise SpeechConfigurationError(
+                "OpenAI SDK がインストールされていません。"
+                "pip install openai を実行してください。"
+            )
+
+        self.api_key = api_key or settings.openai_api_key
+
+        if not self.api_key:
+            raise SpeechConfigurationError(
+                "OpenAI APIキーが設定されていません。"
+                "OPENAI_API_KEY 環境変数を設定してください。"
+            )
+
+        self.client = openai.OpenAI(api_key=self.api_key)
+        self.model = settings.openai_tts_model
+        self.default_voice = settings.openai_tts_voice
+        self.default_speed = settings.openai_tts_speed
+
+    def _get_response_format(self, output_format: OutputFormat) -> Literal["mp3", "opus", "aac", "flac", "wav", "pcm"]:
+        """出力フォーマットをOpenAI TTS APIの形式に変換"""
+        format_mapping: dict[OutputFormat, Literal["mp3", "opus", "aac", "flac", "wav", "pcm"]] = {
+            OutputFormat.WAV: "wav",
+            OutputFormat.MP3: "mp3",
+            OutputFormat.OGG: "opus",  # OpenAI APIではopusとして扱う
+        }
+        return format_mapping.get(output_format, "mp3")
+
+    def _generate_output_path(self, output_format: OutputFormat) -> Path:
+        """出力ファイルパスを自動生成"""
+        output_dir = Path(settings.data_dir) / "speech"
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = f"speech_{uuid.uuid4().hex[:8]}.{output_format.value}"
+        return output_dir / filename
+
+    async def synthesize_speech(self, request: SpeechRequest) -> SpeechResponse:
+        """テキストを音声に変換"""
+        try:
+            # 出力パスの決定
+            output_path = request.output_path or self._generate_output_path(request.output_format)
+
+            # 音声設定
+            voice = request.voice_config.name if hasattr(request.voice_config, 'name') else self.default_voice
+            speed = request.voice_config.speaking_rate if hasattr(request.voice_config, 'speaking_rate') else self.default_speed
+
+            # 速度の範囲チェック (0.25 - 4.0)
+            speed = max(0.25, min(4.0, speed))
+
+            logger.info(f"OpenAI TTS 音声合成開始: {request.text[:50]}...")
+            logger.info(f"設定: model={self.model}, voice={voice}, speed={speed}")
+
+            # OpenAI TTS API呼び出し
+            response = self.client.audio.speech.create(
+                model=self.model,
+                voice=voice,
+                input=request.text,
+                response_format=self._get_response_format(request.output_format),
+                speed=speed
+            )
+
+            # ファイルに書き込み
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            response.stream_to_file(str(output_path))
+
+            # ファイル情報の取得
+            file_size = output_path.stat().st_size if output_path.exists() else 0
+
+            logger.info(f"OpenAI TTS 音声合成完了: {output_path}")
+
+            return SpeechResponse(
+                success=True,
+                output_path=output_path,
+                duration_seconds=None,  # OpenAI APIでは duration が取得できない
+                file_size_bytes=file_size,
+            )
+
+        except openai.APIError as e:
+            if "quota" in str(e).lower():
+                raise SpeechQuotaExceededError(f"OpenAI quota exceeded: {e}") from e
+            raise SpeechServiceError(f"OpenAI TTS API error: {e}") from e
+        except Exception as e:
+            if isinstance(e, SpeechServiceError):
+                raise
+            logger.error(f"OpenAI TTS 音声合成中にエラーが発生: {e}")
+            return SpeechResponse(success=False, error_message=str(e))
+
+    async def get_available_voices(self) -> VoiceListResponse:
+        """利用可能な音声一覧を取得"""
+        # OpenAI TTSの利用可能な音声リスト
+        openai_voices = [
+            VoiceInfo(
+                name="alloy",
+                display_name="Alloy (Natural)",
+                locale="en-US",
+                gender="Neutral",
+                voice_type="Neural",
+                sample_rate_hertz=24000,
+            ),
+            VoiceInfo(
+                name="echo",
+                display_name="Echo (Articulate)",
+                locale="en-US",
+                gender="Male",
+                voice_type="Neural",
+                sample_rate_hertz=24000,
+            ),
+            VoiceInfo(
+                name="fable",
+                display_name="Fable (Warm)",
+                locale="en-US",
+                gender="Neutral",
+                voice_type="Neural",
+                sample_rate_hertz=24000,
+            ),
+            VoiceInfo(
+                name="onyx",
+                display_name="Onyx (Deep)",
+                locale="en-US",
+                gender="Male",
+                voice_type="Neural",
+                sample_rate_hertz=24000,
+            ),
+            VoiceInfo(
+                name="nova",
+                display_name="Nova (Bright)",
+                locale="en-US",
+                gender="Female",
+                voice_type="Neural",
+                sample_rate_hertz=24000,
+            ),
+            VoiceInfo(
+                name="shimmer",
+                display_name="Shimmer (Soft)",
+                locale="en-US",
+                gender="Female",
+                voice_type="Neural",
+                sample_rate_hertz=24000,
+            ),
+        ]
+
+        return VoiceListResponse(voices=openai_voices, total_count=len(openai_voices))
+
+
 class SpeechService:
     """音声サービスのファサード"""
 
     def __init__(self, provider: SpeechProvider | None = None) -> None:
         if provider is None:
-            # 本番環境では Azure プロバイダーを使用
-            if settings.azure_speech_key:
-                provider = AzureSpeechProvider()
+            # 設定に基づいてプロバイダーを選択
+            if settings.speech_provider == "openai":
+                if settings.openai_api_key:
+                    provider = OpenAISpeechProvider()
+                    logger.info("OpenAI TTS プロバイダーを使用します。")
+                else:
+                    logger.warning("OpenAI APIキーが設定されていません。モックプロバイダーを使用します。")
+                    provider = MockSpeechProvider()
+            elif settings.speech_provider == "azure":
+                if settings.azure_speech_key:
+                    provider = AzureSpeechProvider()
+                    logger.info("Azure Speech プロバイダーを使用します。")
+                else:
+                    logger.warning("Azure Speech APIキーが設定されていません。モックプロバイダーを使用します。")
+                    provider = MockSpeechProvider()
             else:
-                # APIキーが設定されていない場合はモックを使用
-                logger.warning("Azure Speech APIキーが設定されていません。モックプロバイダーを使用します。")
+                logger.warning(f"不明なプロバイダー: {settings.speech_provider}。モックプロバイダーを使用します。")
                 provider = MockSpeechProvider()
 
         self.provider = provider
@@ -291,12 +455,19 @@ class SpeechService:
     async def text_to_speech_simple(
         self,
         text: str,
-        voice_name: str = "ja-JP-NanamiNeural",
+        voice_name: str | None = None,
         output_format: OutputFormat = OutputFormat.WAV,
         output_path: Path | None = None,
     ) -> SpeechResponse:
         """シンプルなテキスト音声変換"""
         from .schemas import VoiceConfig
+
+        # プロバイダーに応じたデフォルト音声を設定
+        if voice_name is None:
+            if settings.speech_provider == "openai":
+                voice_name = settings.openai_tts_voice
+            else:
+                voice_name = "ja-JP-NanamiNeural"
 
         voice_config = VoiceConfig(name=voice_name)
         request = SpeechRequest(
@@ -313,7 +484,7 @@ class SpeechService:
         text: str,
         article_title: str,
         content_type: str = "要約",
-        voice_name: str = "ja-JP-NanamiNeural",
+        voice_name: str | None = None,
         output_format: OutputFormat = OutputFormat.WAV,
         output_path: Path | None = None,
     ) -> SpeechResponse:


### PR DESCRIPTION
## Summary
- OpenAI TTS APIを統合し、Azure Speech Serviceと切り替え可能に
- 環境変数`SPEECH_PROVIDER`で音声プロバイダーを選択
- 6種類の音声と2つのモデル（tts-1/tts-1-hd）をサポート

## Changes
### 実装内容
- `OpenAISpeechProvider`クラスを新規実装
- `SpeechService`にプロバイダー切り替えロジックを追加
- 設定に`speech_provider`、`openai_tts_model`、`openai_tts_voice`、`openai_tts_speed`を追加
- docker-compose.ymlに必要な環境変数を追加

### 機能
- **音声オプション**: alloy, echo, fable, onyx, nova, shimmer
- **モデル**: tts-1（低遅延）、tts-1-hd（高品質）
- **速度調整**: 0.25-4.0倍（VoiceConfig制限は2.0まで）
- **出力形式**: WAV, MP3, OGG（OpenAI APIではopusとして処理）

### 設定方法
```bash
# .envファイル
SPEECH_PROVIDER=openai  # または azure
OPENAI_TTS_MODEL=tts-1-hd
OPENAI_TTS_VOICE=nova
OPENAI_TTS_SPEED=1.0
```

## Test plan
- [x] `make test`で全73テストがパス
- [x] `make ruff`でリントエラーなし
- [x] `make mypy`で型エラーなし
- [x] ローカル環境で実際の記事で音声生成を確認

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)